### PR TITLE
Oculus: Grip pressure, Enter btn, fix btn constants

### DIFF
--- a/src/vr.h
+++ b/src/vr.h
@@ -124,6 +124,7 @@ public:
 		float  dpad[2]; //!< Dpad / touchpad position (u,v).
 		float  stick[2];   //!< Joystick / thumbstick position (u,v).
 		float trigger_pressure; //!< Analog trigger pressure (0~1) (if available).
+		float grip_pressure; //!< Analog grip pressure (0~1) (if available).
 		Controller();       //!< Constructor (null-init)
 	} Controller; //!< Controller
 

--- a/src/vr_oculus.cpp
+++ b/src/vr_oculus.cpp
@@ -488,13 +488,16 @@ int VR_Oculus::updateTracking()
 
 		// Convert Oculus button bits to Widget_Layout button bits.
 		btn_press = btn_touch = 0;
-		if (input_state.Buttons & ovrTouch_X) {
+		if (input_state.Buttons & ovrButton_X) {
 			btn_press |= VR_OCULUS_BTNBIT_X;
 		}
-		if (input_state.Buttons & ovrTouch_Y) {
+		if (input_state.Buttons & ovrButton_Y) {
 			btn_press |= VR_OCULUS_BTNBIT_Y;
 		}
-		if (input_state.Buttons & ovrTouch_LThumb) {
+		if (input_state.Buttons & ovrButton_Enter) {
+			btn_press |= VR_OCULUS_BTNBIT_E;
+		}
+		if (input_state.Buttons & ovrButton_LThumb) {
 			btn_press |= VR_OCULUS_BTNBIT_LEFTSTICK;
 		}
 		btn_touch = btn_press;
@@ -540,10 +543,12 @@ int VR_Oculus::updateTracking()
 				this->controller[Side_Left].trigger_pressure = (input_state.IndexTrigger[ovrHand_Left] - VR_OCULUS_PRESSTHRESHOLD_INDEXTRIGGER) / (1.0 - VR_OCULUS_PRESSTHRESHOLD_INDEXTRIGGER);
 			}
 		}
+		this->controller[Side_Left].grip_pressure = 0.0f;
 		if (input_state.HandTrigger[ovrHand_Left] > VR_OCULUS_TOUCHTHRESHOLD_SHOULDERGRIP) {
 			btn_touch |= VR_OCULUS_BTNBIT_LEFTGRIP;
 			if (input_state.HandTrigger[ovrHand_Left] > VR_OCULUS_PRESSTHRESHOLD_SHOULDERGRIP) {
 				btn_press |= VR_OCULUS_BTNBIT_LEFTGRIP;
+				this->controller[Side_Left].grip_pressure = (input_state.HandTrigger[ovrHand_Left] - VR_OCULUS_PRESSTHRESHOLD_SHOULDERGRIP) / (1.0 - VR_OCULUS_PRESSTHRESHOLD_SHOULDERGRIP);
 			}
 		}
 		// add touch information
@@ -576,13 +581,13 @@ int VR_Oculus::updateTracking()
 
 		// Convert Oculus button bits to Widget_Layout button bits.
 		btn_press = btn_touch = 0;
-		if (input_state.Buttons & ovrTouch_A) {
+		if (input_state.Buttons & ovrButton_A) {
 			btn_press |= VR_OCULUS_BTNBIT_A;
 		}
-		if (input_state.Buttons & ovrTouch_B) {
+		if (input_state.Buttons & ovrButton_B) {
 			btn_press |= VR_OCULUS_BTNBIT_B;
 		}
-		if (input_state.Buttons & ovrTouch_RThumb) {
+		if (input_state.Buttons & ovrButton_RThumb) {
 			btn_press |= VR_OCULUS_BTNBIT_RIGHTSTICK;
 		}
 		btn_touch = btn_press;
@@ -627,10 +632,12 @@ int VR_Oculus::updateTracking()
 				this->controller[Side_Right].trigger_pressure = (input_state.IndexTrigger[ovrHand_Right] - VR_OCULUS_PRESSTHRESHOLD_INDEXTRIGGER) / (1.0 - VR_OCULUS_PRESSTHRESHOLD_INDEXTRIGGER);
 			}
 		}
+		this->controller[Side_Right].grip_pressure = 0.0f;
 		if (input_state.HandTrigger[ovrHand_Right] > VR_OCULUS_TOUCHTHRESHOLD_SHOULDERGRIP) {
 			btn_touch |= VR_OCULUS_BTNBIT_RIGHTGRIP;
 			if (input_state.HandTrigger[ovrHand_Right] > VR_OCULUS_PRESSTHRESHOLD_SHOULDERGRIP) {
 				btn_press |= VR_OCULUS_BTNBIT_RIGHTGRIP;
+				this->controller[Side_Right].grip_pressure = (input_state.HandTrigger[ovrHand_Right] - VR_OCULUS_PRESSTHRESHOLD_SHOULDERGRIP) / (1.0 - VR_OCULUS_PRESSTHRESHOLD_SHOULDERGRIP);
 			}
 		}
 		// add touch information

--- a/src/vr_oculus.h
+++ b/src/vr_oculus.h
@@ -42,6 +42,7 @@
 #define VR_OCULUS_BTNBIT_Y				(uint64_t(1) << 19)		//!< Button bit for pressing the "Y" button.
 #define VR_OCULUS_BTNBIT_A				(uint64_t(1) << 20)		//!< Button bit for pressing the "A" button.
 #define VR_OCULUS_BTNBIT_B				(uint64_t(1) << 21)		//!< Button bit for pressing the "B" button.
+#define VR_OCULUS_BTNBIT_E				(uint64_t(1) << 22)		//!< Button bit for pressing the "Enter" button.
 
 // Static-use wrapper for use in C projects that can't use the class definition.
 extern "C" __declspec(dllexport) int c_createVR();	//!< Create n object internally. Must be called before the functions below.


### PR DESCRIPTION
Just a few updates for future use.
Fixed constants for button press bits ovrTouch_* -> ovrButton_* While the values are currently the same but that is still different constants.
Added "Enter" button for oculus touch (located on the left hand controller) which is typically used to spawn application specific menu
Added grip pressure for future use